### PR TITLE
Piper/filter handling for snapshot and revert

### DIFF
--- a/eth_tester/backends/pyethereum/v16/main.py
+++ b/eth_tester/backends/pyethereum/v16/main.py
@@ -17,6 +17,7 @@ from eth_utils import (
 
 from eth_tester.exceptions import (
     TransactionNotFound,
+    BlockNotFound,
 )
 from eth_tester.backends.base import BaseChainBackend
 from eth_tester.backends.pyethereum.utils import (
@@ -76,7 +77,7 @@ def _get_block_by_number(evm, block_number="latest"):
         return evm.block
     else:
         if block_number >= len(evm.blocks):
-            raise ValueError("Block number is longer than current chain.")
+            raise BlockNotFound("Block number is longer than current chain.")
         return evm.blocks[block_number]
 
 
@@ -87,7 +88,7 @@ def _get_block_by_hash(evm, block_hash):
         if block.hash == block_hash:
             return block
     else:
-        raise ValueError("Could not find block for provided hash")
+        raise BlockNotFound("Could not find block for provided hash")
 
 
 def _send_evm_transaction(tester_module, evm, transaction):

--- a/eth_tester/backends/pyethereum/v16/main.py
+++ b/eth_tester/backends/pyethereum/v16/main.py
@@ -75,6 +75,8 @@ def _get_block_by_number(evm, block_number="latest"):
         return evm.blocks[0]
     elif block_number == "pending":
         return evm.block
+    elif block_number == evm.block.number:
+        return evm.block
     else:
         if block_number >= len(evm.blocks):
             raise BlockNotFound("Block number is longer than current chain.")
@@ -88,6 +90,8 @@ def _get_block_by_hash(evm, block_hash):
         if block.hash == block_hash:
             return block
     else:
+        if block_hash == evm.block.hash:
+            return evm.block
         raise BlockNotFound("Could not find block for provided hash")
 
 

--- a/eth_tester/exceptions.py
+++ b/eth_tester/exceptions.py
@@ -2,6 +2,10 @@ class ValidationError(Exception):
     pass
 
 
+class BlockNotFound(Exception):
+    pass
+
+
 class TransactionNotFound(Exception):
     pass
 

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -190,12 +190,11 @@ class EthereumTester(object):
 
     def _revert_block_filter(self, filter):
         is_invalid_block_hash = excepts(
-            BlockNotFound,
+            (BlockNotFound,),
             complement(compose(bool, self.get_block_by_hash)),
             lambda v: True,
         )
         values_to_remove = remove(is_invalid_block_hash, filter.get_all())
-        assert False
         filter.remove(*values_to_remove)
 
     def _revert_pending_transaction_filter(self, filter):

--- a/eth_tester/main.py
+++ b/eth_tester/main.py
@@ -1,6 +1,12 @@
 import itertools
 
+from toolz.itertoolz import (
+    remove,
+)
 from toolz.functoolz import (
+    complement,
+    compose,
+    excepts,
     partial,
 )
 
@@ -9,6 +15,7 @@ from eth_utils import (
 )
 
 from eth_tester.exceptions import (
+    BlockNotFound,
     FilterNotFound,
     SnapshotNotFound,
     TransactionNotFound,
@@ -173,6 +180,29 @@ class EthereumTester(object):
             raise SnapshotNotFound("No snapshot found for id: {0}".format(snapshot_id))
         else:
             self.backend.revert_to_snapshot(snapshot)
+
+        for block_filter in self._block_filters.values():
+            self._revert_block_filter(block_filter)
+        for pending_transaction_filter in self._pending_transaction_filters.values():
+            self._revert_pending_transaction_filter(pending_transaction_filter)
+        for log_filter in self._log_filters.values():
+            self._revert_log_filter(filter)
+
+    def _revert_block_filter(self, filter):
+        is_invalid_block_hash = excepts(
+            BlockNotFound,
+            complement(compose(bool, self.get_block_by_hash)),
+            lambda v: True,
+        )
+        values_to_remove = remove(is_invalid_block_hash, filter.get_all())
+        assert False
+        filter.remove(*values_to_remove)
+
+    def _revert_pending_transaction_filter(self, filter):
+        raise NotImplementedError("not yet implemented")
+
+    def _revert_log_filter(self, filter):
+        raise NotImplementedError("not yet implemented")
 
     def reset_to_genesis(self):
         self.backend.reset_to_genesis()

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -286,61 +286,189 @@ class BaseTestBackendDirect(object):
         assert eth_tester.get_block_by_number('latest')['number'] == 4
         assert eth_tester.get_block_by_number('pending')['number'] == 5
 
-    def test_revert_cleans_up_invalidated_pending_block_logs(self, eth_tester):
+    def test_revert_cleans_up_invalidated_pending_block_filters(self, eth_tester):
         # first mine 10 blocks in
-        eth_tester.mine_blocks(5)
+        eth_tester.mine_blocks(2)
 
         # setup a filter
         filter_a_id = eth_tester.create_block_filter()
         filter_b_id = eth_tester.create_block_filter()
 
         # mine 5 blocks before the snapshot
-        common_blocks = eth_tester.mine_blocks(5)
+        common_blocks = set(eth_tester.mine_blocks(2))
 
         snapshot_id = eth_tester.take_snapshot()
 
         # mine another 5 blocks
-        eth_tester.send_transaction({
+        fork_a_transaction_hash = eth_tester.send_transaction({
             "from": eth_tester.get_accounts()[0],
             "to": BURN_ADDRESS,
             "gas": 21000,
             "value": 1,
         })
-        fork_a_blocks = eth_tester.mine_blocks(5)
+        fork_a_transaction_block_hash = eth_tester.get_transaction_by_hash(
+            fork_a_transaction_hash,
+        )['block_hash']
+        fork_a_blocks = eth_tester.mine_blocks(2)
 
-        before_revert_changes_logs_a = eth_tester.get_all_filter_logs(filter_a_id)
+        before_revert_changes_logs_a = eth_tester.get_only_filter_changes(filter_a_id)
         before_revert_all_logs_a = eth_tester.get_all_filter_logs(filter_a_id)
         before_revert_all_logs_b = eth_tester.get_all_filter_logs(filter_b_id)
 
+        assert common_blocks.intersection(before_revert_changes_logs_a) == common_blocks
+        assert common_blocks.intersection(before_revert_all_logs_a) == common_blocks
+        assert common_blocks.intersection(before_revert_all_logs_b) == common_blocks
+
+        expected_before_block_hashes = common_blocks.union([
+            fork_a_transaction_block_hash,
+        ]).union(fork_a_blocks)
+
         # sanity check that the filters picked up on the log changes.
-        assert len(before_revert_changes_logs_a) == 11
-        assert len(before_revert_all_logs_a) == 11
-        assert len(before_revert_all_logs_b) == 11
+        assert set(before_revert_changes_logs_a) == expected_before_block_hashes
+        assert set(before_revert_changes_logs_a) == expected_before_block_hashes
+        assert set(before_revert_all_logs_a) == expected_before_block_hashes
+        assert set(before_revert_all_logs_b) == expected_before_block_hashes
 
         # now revert to snapshot
         eth_tester.revert_to_snapshot(snapshot_id)
 
         # send a different transaction to ensure our new blocks are different
-        eth_tester.send_transaction({
+        fork_b_transaction_hash = eth_tester.send_transaction({
             "from": eth_tester.get_accounts()[0],
             "to": BURN_ADDRESS,
             "gas": 21000,
             "value": 2,
         })
-        fork_b_blocks = eth_tester.mine_blocks(5)
+        fork_b_transaction_block_hash = eth_tester.get_transaction_by_hash(
+            fork_b_transaction_hash,
+        )['block_hash']
+        fork_b_blocks = eth_tester.mine_blocks(2)
 
         # check that are blocks don't intersect
         assert not set(fork_a_blocks).intersection(fork_b_blocks)
 
-        after_revert_changes_logs_a = eth_tester.get_all_filter_logs(filter_a_id)
-        after_revert_changes_logs_b = eth_tester.get_all_filter_logs(filter_b_id)
+        after_revert_changes_logs_a = eth_tester.get_only_filter_changes(filter_a_id)
+        after_revert_changes_logs_b = eth_tester.get_only_filter_changes(filter_b_id)
         after_revert_all_logs_a = eth_tester.get_all_filter_logs(filter_a_id)
         after_revert_all_logs_b = eth_tester.get_all_filter_logs(filter_b_id)
 
-        assert len(after_revert_changes_logs_a) == 11
-        assert len(after_revert_changes_logs_b) == 11
-        assert len(after_revert_all_logs_a) == 11
-        assert len(after_revert_all_logs_b) == 11
+        expected_all_after_blocks = common_blocks.union([
+            fork_b_transaction_block_hash,
+        ]).union(fork_b_blocks)
+        expected_new_after_blocks = set(fork_b_blocks).union([
+            fork_b_transaction_block_hash,
+        ])
+
+        assert set(after_revert_changes_logs_a) == expected_new_after_blocks
+        assert set(after_revert_changes_logs_b) == expected_all_after_blocks
+        assert set(after_revert_all_logs_a) == expected_all_after_blocks
+        assert set(after_revert_all_logs_b) == expected_all_after_blocks
+
+    def test_revert_cleans_up_invalidated_pending_transaction_filters(self, eth_tester):
+        def _transaction(**kwargs):
+            return merge(
+                {"from": eth_tester.get_accounts()[0], "to": BURN_ADDRESS, "gas": 21000},
+                kwargs,
+            )
+
+        # send a few initial transactions
+        for _ in range(5):
+            eth_tester.send_transaction(_transaction())
+
+        # setup a filter
+        filter_id = eth_tester.create_pending_transaction_filter()
+
+        # send 2 transactions
+        common_transactions = set([
+            eth_tester.send_transaction(_transaction(value=1)),
+            eth_tester.send_transaction(_transaction(value=2)),
+        ])
+
+        # take a snapshot
+        snapshot_id = eth_tester.take_snapshot()
+
+        # send 3 transactions
+        before_transactions = [
+            eth_tester.send_transaction(_transaction(value=3)),
+            eth_tester.send_transaction(_transaction(value=4)),
+            eth_tester.send_transaction(_transaction(value=5)),
+        ]
+
+        # pull and sanity check the filter changes
+        before_filter_changes = eth_tester.get_only_filter_changes(filter_id)
+        before_filter_logs = eth_tester.get_all_filter_logs(filter_id)
+
+        assert set(before_filter_changes) == common_transactions.union(before_transactions)
+        assert set(before_filter_logs) == common_transactions.union(before_transactions)
+
+        # revert the chain
+        eth_tester.revert_to_snapshot(snapshot_id)
+
+        # send 3 transactions on the new fork
+        after_transactions = [
+            eth_tester.send_transaction(_transaction(value=6)),
+            eth_tester.send_transaction(_transaction(value=7)),
+            eth_tester.send_transaction(_transaction(value=8)),
+        ]
+
+        # pull and sanity check the filter changes
+        after_filter_changes = eth_tester.get_only_filter_changes(filter_id)
+        after_filter_logs = eth_tester.get_all_filter_logs(filter_id)
+
+        assert set(after_filter_changes) == set(after_transactions)
+        assert set(after_filter_logs) == common_transactions.union(after_transactions)
+
+    def test_revert_cleans_up_invalidated_log_entries(self, eth_tester):
+        # setup the emitter
+        emitter_address = _deploy_emitter(eth_tester)
+
+        def _emit(v):
+            return _call_emitter(
+                eth_tester,
+                emitter_address,
+                'logSingle',
+                [EMITTER_ENUM['LogSingleWithIndex'], v],
+            )
+
+        # emit 2 logs pre-filtering
+        _emit(1)
+        _emit(2)
+
+        # setup a filter
+        filter_id = eth_tester.create_log_filter()
+
+        # emit 2 logs pre-snapshot
+        _emit(1)
+        _emit(2)
+
+        # take a snapshot
+        snapshot_id = eth_tester.take_snapshot()
+
+        # emit 3 logs after-snapshot
+        _emit(3)
+        _emit(4)
+        _emit(5)
+
+        before_changes = eth_tester.get_only_filter_changes(filter_id)
+        before_all = eth_tester.get_all_filter_logs(filter_id)
+
+        assert len(before_changes) == 5
+        assert len(before_all) == 5
+
+        # revert the chain
+        eth_tester.revert_to_snapshot(snapshot_id)
+
+        # emit 4 logs after-reverting
+        _emit(6)
+        _emit(7)
+        _emit(8)
+        _emit(9)
+
+        after_changes = eth_tester.get_only_filter_changes(filter_id)
+        after_all = eth_tester.get_all_filter_logs(filter_id)
+
+        assert len(after_changes) == 4
+        assert len(after_all) == 6
 
     def test_reset_to_genesis(self, eth_tester):
         eth_tester.mine_blocks(5)

--- a/eth_tester/utils/backend_testing.py
+++ b/eth_tester/utils/backend_testing.py
@@ -293,10 +293,11 @@ class BaseTestBackendDirect(object):
         # setup a filter
         filter_a_id = eth_tester.create_block_filter()
         filter_b_id = eth_tester.create_block_filter()
-        snapshot_id = eth_tester.take_snapshot()
 
-        # first mine 10 blocks in
-        eth_tester.mine_blocks(5)
+        # mine 5 blocks before the snapshot
+        common_blocks = eth_tester.mine_blocks(5)
+
+        snapshot_id = eth_tester.take_snapshot()
 
         # mine another 5 blocks
         eth_tester.send_transaction({

--- a/eth_tester/utils/filters.py
+++ b/eth_tester/utils/filters.py
@@ -56,7 +56,7 @@ class Filter(object):
         for value in queued_values:
             if value in values_to_remove:
                 continue
-            self.add(value)
+            self.queue.put_nowait(value)
 
 
 def is_tuple(value):

--- a/eth_tester/utils/filters.py
+++ b/eth_tester/utils/filters.py
@@ -45,12 +45,17 @@ class Filter(object):
             self.queue.put_nowait(item)
 
     def remove(self, *values):
-        values_to_remove = set(values)
+        try:
+            values_to_remove = set(values)
+        except TypeError:
+            # log filters are dicts which are not hashable
+            values_to_remove = values
+
         queued_values = self.get_changes()
         self.values = [
             value
             for value
-            in self.values
+            in self.get_all()
             if value not in values_to_remove
         ]
         for value in queued_values:

--- a/eth_tester/utils/filters.py
+++ b/eth_tester/utils/filters.py
@@ -44,6 +44,20 @@ class Filter(object):
             self.values.append(item)
             self.queue.put_nowait(item)
 
+    def remove(self, *values):
+        values_to_remove = set(values)
+        queued_values = self.get_changes()
+        self.values = [
+            value
+            for value
+            in self.values
+            if value not in values_to_remove
+        ]
+        for value in queued_values:
+            if value in values_to_remove:
+                continue
+            self.add(value)
+
 
 def is_tuple(value):
     return isinstance(value, tuple)


### PR DESCRIPTION
Fixes snapshot reversion such that it cleans up the existing filters to remove values that are now invalid post reversion.